### PR TITLE
110289 data conversion amend db cols

### DIFF
--- a/ProcessApplicationForm.Test/Data/TestData.cs
+++ b/ProcessApplicationForm.Test/Data/TestData.cs
@@ -34,7 +34,8 @@ public static class TestData
             ChangesToLaGovernance = 907660000,
             ChangesToTrust = 907660000,
             FormTrustGrowthPlansYesNo = 907660000,
-            FormTrustReasonApprovalToConvertAsSat = 907660000
+            FormTrustReasonApprovalToConvertAsSat = 907660000,
+            DynamicsApplicationId = Guid.Empty
         };
 
         A2BApplicationData = new()
@@ -75,7 +76,8 @@ public static class TestData
             TrustName = StagingApplicationData.TrustName,
             ApplicationSubmittedOn = StagingApplicationData.ApplicationSubmittedOn,
             ApplyingSchools = new HashSet<A2BApplicationApplyingSchool>(),
-            KeyPersons = new HashSet<A2BApplicationKeyPerson>()
+            KeyPersons = new HashSet<A2BApplicationKeyPerson>(),
+            DynamicsApplicationId = Guid.Empty
         };
 
         StagingApplyingSchoolData = fixture.Create<StagingApplyingSchool>() with
@@ -110,7 +112,9 @@ public static class TestData
             SchoolNFYRevenueSurplusOrDeficit = 907660000,
             SchoolSupportGrantFundsPaidTo = 907660000,
             SchoolConversionContactRole = 90760000,
-            Urn = 1
+            Urn = 1,
+            LocalAuthorityName = "city counsil",
+            DynamicsApplyingSchoolId = Guid.Empty
         };
 
         A2BApplicationApplyingSchoolData = new()
@@ -251,7 +255,8 @@ public static class TestData
             KeyPersonFinancialDirector = StagingKeyPersonData.KeyPersonFinancialDirector,
             KeyPersonMember = StagingKeyPersonData.KeyPersonMember,
             KeyPersonOther = StagingKeyPersonData.KeyPersonOther,
-            KeyPersonTrustee = StagingKeyPersonData.KeyPersonTrustee
+            KeyPersonTrustee = StagingKeyPersonData.KeyPersonTrustee,
+            DynamicsKeyPersonId = StagingKeyPersonData.DynamicsKeyPersonId
         };
 
         StagingSchoolLeaseData = fixture.Create<StagingSchoolLease>();
@@ -264,7 +269,8 @@ public static class TestData
             SchoolLeaseRepaymentValue = StagingSchoolLeaseData.SchoolLeaseRepaymentValue,
             SchoolLeaseResponsibleForAssets = StagingSchoolLeaseData.SchoolLeaseResponsibleForAssets,
             SchoolLeaseTerm = StagingSchoolLeaseData.SchoolLeaseTerm,
-            SchoolLeaseValueOfAssets = StagingSchoolLeaseData.SchoolLeaseValueOfAssets
+            SchoolLeaseValueOfAssets = StagingSchoolLeaseData.SchoolLeaseValueOfAssets,
+            DynamicsSchoolLeaseId = StagingSchoolLeaseData.DynamicsSchoolLeaseId
         };
 
         StagingSchoolLoanData = fixture.Create<StagingSchoolLoan>();
@@ -275,7 +281,8 @@ public static class TestData
             SchoolLoanInterestRate = StagingSchoolLoanData.SchoolLoanInterestRate,
             SchoolLoanProvider = StagingSchoolLoanData.SchoolLoanProvider,
             SchoolLoanPurpose = StagingSchoolLoanData.SchoolLoanPurpose,
-            SchoolLoanSchedule = StagingSchoolLoanData.SchoolLoanSchedule
+            SchoolLoanSchedule = StagingSchoolLoanData.SchoolLoanSchedule,
+            DynamicsSchoolLoanId = StagingSchoolLoanData.DynamicsSchoolLoanId
         };
         
         AcademyConversionProjectData = new()

--- a/ProcessApplicationForm.Test/Data/TestData.cs
+++ b/ProcessApplicationForm.Test/Data/TestData.cs
@@ -114,7 +114,8 @@ public static class TestData
             SchoolConversionContactRole = 90760000,
             Urn = 1,
             LocalAuthorityName = "city counsil",
-            DynamicsApplyingSchoolId = Guid.Empty
+            DynamicsApplyingSchoolId = Guid.Empty,
+            DynamicsApplicationId = Guid.Empty
         };
 
         A2BApplicationApplyingSchoolData = new()

--- a/ProcessApplicationFormFunction/Database/Models/A2BApplication.cs
+++ b/ProcessApplicationFormFunction/Database/Models/A2BApplication.cs
@@ -60,5 +60,8 @@ namespace ProcessApplicationFormFunction.Database.Models
         
         [ForeignKey(nameof(ApplicationId))]
         public virtual ICollection<A2BApplicationApplyingSchool> ApplyingSchools { get; set; }
+
+        // MR:- below mods for Dynamics -> SQL server A2B external app conversion
+        public Guid DynamicsApplicationId { get; set; }
     }
 }

--- a/ProcessApplicationFormFunction/Database/Models/A2BApplicationApplyingSchool.cs
+++ b/ProcessApplicationFormFunction/Database/Models/A2BApplicationApplyingSchool.cs
@@ -134,5 +134,7 @@ namespace ProcessApplicationFormFunction.Database.Models
 
         // MR:- below mods for Dynamics -> SQL server A2B external app conversion
         public Guid DynamicsApplyingSchoolId { get; set; }
+
+        public Guid DynamicsApplicationId { get; set; }
     }
 }

--- a/ProcessApplicationFormFunction/Database/Models/A2BApplicationApplyingSchool.cs
+++ b/ProcessApplicationFormFunction/Database/Models/A2BApplicationApplyingSchool.cs
@@ -128,10 +128,11 @@ namespace ProcessApplicationFormFunction.Database.Models
         public string ApplicationId { get; set; }
         public virtual A2BApplication A2BApplication { get; set; }
         
-        [NotMapped]
         public int Urn { get; set; }
         
-        [NotMapped]
         public string LocalAuthorityName { get; set; }
+
+        // MR:- below mods for Dynamics -> SQL server A2B external app conversion
+        public Guid DynamicsApplyingSchoolId { get; set; }
     }
 }

--- a/ProcessApplicationFormFunction/Database/Models/A2BApplicationKeyPerson.cs
+++ b/ProcessApplicationFormFunction/Database/Models/A2BApplicationKeyPerson.cs
@@ -24,5 +24,8 @@ namespace ProcessApplicationFormFunction.Database.Models
         
         public string ApplicationId { get; set; }
         public virtual A2BApplication A2BApplication { get; set; }
+
+        // MR:- below mods for Dynamics -> SQL server A2B external app conversion
+        public Guid DynamicsKeyPersonId { get; set; }
     }
 }

--- a/ProcessApplicationFormFunction/Database/Models/A2BSchoolLease.cs
+++ b/ProcessApplicationFormFunction/Database/Models/A2BSchoolLease.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -26,5 +27,8 @@ namespace ProcessApplicationFormFunction.Database.Models
         
         public int ApplyingSchoolId { get; set; }
         public virtual A2BApplicationApplyingSchool A2BApplicationApplyingSchool { get; set; }
+
+        // MR:- below mods for Dynamics -> SQL server A2B external app conversion
+        public Guid DynamicsSchoolLeaseId { get; set; }
     }
 }

--- a/ProcessApplicationFormFunction/Database/Models/A2BSchoolLoan.cs
+++ b/ProcessApplicationFormFunction/Database/Models/A2BSchoolLoan.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -19,5 +20,8 @@ namespace ProcessApplicationFormFunction.Database.Models
         
         public int ApplyingSchoolId { get; set; }
         public virtual A2BApplicationApplyingSchool A2BApplicationApplyingSchool { get; set; }
+
+        // MR:- below mods for Dynamics -> SQL server A2B external app conversion
+        public Guid DynamicsSchoolLoanId { get; set; }
     }
 }

--- a/ProcessApplicationFormFunction/Mappers/ApplicationMapper.cs
+++ b/ProcessApplicationFormFunction/Mappers/ApplicationMapper.cs
@@ -57,7 +57,8 @@ public class ApplicationMapper : IMapper<StagingApplication, A2BApplication>
             TrustName = stagingApplication.TrustName,
             ApplicationSubmittedOn = stagingApplication.ApplicationSubmittedOn,
             ApplyingSchools = _applyingSchoolMapper.Map(stagingApplication.ApplyingSchools).ToHashSet(),
-            KeyPersons = _keyPersonMapper.Map(stagingApplication.KeyPersons).ToHashSet()
+            KeyPersons = _keyPersonMapper.Map(stagingApplication.KeyPersons).ToHashSet(),
+            DynamicsApplicationId = stagingApplication.DynamicsApplicationId
         });
     }    
 }

--- a/ProcessApplicationFormFunction/Mappers/ApplyingSchoolMapper.cs
+++ b/ProcessApplicationFormFunction/Mappers/ApplyingSchoolMapper.cs
@@ -117,7 +117,8 @@ public class ApplyingSchoolMapper : IMapper<StagingApplyingSchool, A2BApplicatio
             SchoolLoans = _schoolLoanMapper.Map(applyingSchool.SchoolLoans).ToHashSet(),
             
             Urn = applyingSchool.Urn,
-            LocalAuthorityName = applyingSchool.LocalAuthorityName
+            LocalAuthorityName = applyingSchool.LocalAuthorityName,
+            DynamicsApplyingSchoolId = applyingSchool.DynamicsApplyingSchoolId
         });
     }
 }

--- a/ProcessApplicationFormFunction/Mappers/ApplyingSchoolMapper.cs
+++ b/ProcessApplicationFormFunction/Mappers/ApplyingSchoolMapper.cs
@@ -118,7 +118,8 @@ public class ApplyingSchoolMapper : IMapper<StagingApplyingSchool, A2BApplicatio
             
             Urn = applyingSchool.Urn,
             LocalAuthorityName = applyingSchool.LocalAuthorityName,
-            DynamicsApplyingSchoolId = applyingSchool.DynamicsApplyingSchoolId
+            DynamicsApplyingSchoolId = applyingSchool.DynamicsApplyingSchoolId,
+            DynamicsApplicationId = applyingSchool.DynamicsApplicationId
         });
     }
 }

--- a/ProcessApplicationFormFunction/Mappers/KeyPersonMapper.cs
+++ b/ProcessApplicationFormFunction/Mappers/KeyPersonMapper.cs
@@ -17,6 +17,7 @@ public class KeyPersonMapper : IMapper<StagingKeyPerson, A2BApplicationKeyPerson
             KeyPersonDateOfBirth = keyPerson.KeyPersonDateOfBirth,
             KeyPersonChairOfTrust = keyPerson.KeyPersonChairOfTrust,
             KeyPersonBiography = keyPerson.KeyPersonBiography,
-            KeyPersonCeoExecutive = keyPerson.KeyPersonCeoExecutive
+            KeyPersonCeoExecutive = keyPerson.KeyPersonCeoExecutive,
+            DynamicsKeyPersonId = keyPerson.DynamicsKeyPersonId
         });
 }

--- a/ProcessApplicationFormFunction/Mappers/SchoolLeaseMapper.cs
+++ b/ProcessApplicationFormFunction/Mappers/SchoolLeaseMapper.cs
@@ -15,6 +15,7 @@ public class SchoolLeaseMapper : IMapper<StagingSchoolLease, A2BSchoolLease>
             SchoolLeaseRepaymentValue = schoolLease.SchoolLeaseRepaymentValue,
             SchoolLeaseResponsibleForAssets = schoolLease.SchoolLeaseResponsibleForAssets,
             SchoolLeaseTerm = schoolLease.SchoolLeaseTerm,
-            SchoolLeaseValueOfAssets = schoolLease.SchoolLeaseValueOfAssets            
+            SchoolLeaseValueOfAssets = schoolLease.SchoolLeaseValueOfAssets,
+            DynamicsSchoolLeaseId = schoolLease.DynamicsSchoolLeaseId
         });
 }

--- a/ProcessApplicationFormFunction/Mappers/SchoolLoanMapper.cs
+++ b/ProcessApplicationFormFunction/Mappers/SchoolLoanMapper.cs
@@ -13,6 +13,7 @@ public class SchoolLoanMapper : IMapper<StagingSchoolLoan, A2BSchoolLoan>
             SchoolLoanInterestRate = schoolLoan.SchoolLoanInterestRate,
             SchoolLoanProvider = schoolLoan.SchoolLoanProvider,
             SchoolLoanPurpose = schoolLoan.SchoolLoanPurpose,
-            SchoolLoanSchedule = schoolLoan.SchoolLoanSchedule
+            SchoolLoanSchedule = schoolLoan.SchoolLoanSchedule,
+            DynamicsSchoolLoanId = schoolLoan.DynamicsSchoolLoanId
         });
 }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Please follow the section below relevent to your development environment
   * Settings > Tools tab: "Azure". Select the Functions subsection, and install the latest version of the Azure Functions Core Tools. Restart Rider.
 </details>
 
-You will need to run locally against **Dev** and ensure you have either an environment variable, secret or a local.settings.json file with
+You will need to run locally against **Dev** and ensure you have an environment variable with
 the following value set to the the connection string for **Dev Database**:
 
 `SQLAZURECONNSTR_SqlConnectionString`
@@ -45,6 +45,9 @@ _Note: As we cannot run the ADF pipeline against local Db, we will not have the 
  
 Once you have this in place you will be able to run locally and after a few seconds your output window should show the link call the http trigger.
 For example: ProcessApplicationForm: [GET] http://localhost:7071/api/ProcessApplicationForm
+
+visual studio user secrets won't work, see:-
+https://dombarter.co.uk/posts/azure-functions-app-settings/
 
 ## Authorisation
   

--- a/func-applytobecome-processapplicationform.sln
+++ b/func-applytobecome-processapplicationform.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E26D7FA1-5DDF-42B9-8A26-8030FD69AB18}"
 	ProjectSection(SolutionItems) = preProject
 		localsettings.json = localsettings.json
+		README.md = README.md
 	EndProjectSection
 EndProject
 Global

--- a/sddSchemaMods/1- [sdd].[A2BApplication].sql
+++ b/sddSchemaMods/1- [sdd].[A2BApplication].sql
@@ -1,0 +1,98 @@
+BEGIN TRY
+BEGIN TRANSACTION CreateNewSddSchemaTableColumns
+
+	/*** application table ***/
+	IF NOT EXISTS
+	(
+		SELECT *
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = 'sdd'
+		AND TABLE_NAME = 'A2BApplication'
+		AND COLUMN_NAME = 'DynamicsApplicationId'
+	)
+	BEGIN
+		ALTER TABLE [sdd].[A2BApplication]
+		ADD	DynamicsApplicationId uniqueidentifier NULL
+	END
+
+	/*** [sdd].[A2BApplicationApplyingSchool] school table ***/
+	--urn && LA name
+	IF NOT EXISTS
+	(
+		SELECT *
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = 'sdd'
+		AND TABLE_NAME = 'A2BApplicationApplyingSchool'
+		AND COLUMN_NAME = 'DynamicsKeyPersonId'
+	)
+	BEGIN
+		ALTER TABLE [sdd].[A2BApplicationApplyingSchool]
+		ADD	DynamicsApplyingSchoolId uniqueidentifier NULL,
+			Urn int NULL,
+			LocalAuthorityName nvarchar(max) NULL
+	END
+
+	/*** [sdd].[A2BApplicationKeyPersons] ***/
+	IF NOT EXISTS
+	(
+		SELECT *
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = 'sdd'
+		AND TABLE_NAME = 'A2BApplicationKeyPersons'
+		AND COLUMN_NAME = 'DynamicsKeyPersonId'
+	)
+	BEGIN
+		ALTER TABLE [sdd].[A2BApplicationKeyPersons]
+		ADD	DynamicsKeyPersonId uniqueidentifier NULL
+	END
+
+	/*** [sdd].[A2BSchoolLease] ***/
+	IF NOT EXISTS
+	(
+		SELECT *
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = 'sdd'
+		AND TABLE_NAME = 'A2BSchoolLease'
+		AND COLUMN_NAME = 'DynamicsSchoolLeaseId'
+	)
+	BEGIN
+		ALTER TABLE [sdd].[A2BSchoolLease]
+		ADD	DynamicsSchoolLeaseId uniqueidentifier NULL
+	END
+
+	/*** [sdd].[A2BSchoolLoan] ***/
+	IF NOT EXISTS
+	(
+		SELECT *
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = 'sdd'
+		AND TABLE_NAME = 'A2BSchoolLoan'
+		AND COLUMN_NAME = 'DynamicsSchoolLoanId'
+	)
+	BEGIN
+		ALTER TABLE [sdd].[A2BSchoolLoan]
+		ADD	DynamicsSchoolLoanId uniqueidentifier NULL
+	END
+
+	--COMMIT TRAN CreateNewSddSchemaTableColumns
+	--ROLLBACK TRAN CreateNewSddSchemaTableColumns
+
+END TRY
+BEGIN CATCH
+  SELECT
+    ERROR_NUMBER() AS ErrorNumber,
+    ERROR_STATE() AS ErrorState,
+    ERROR_SEVERITY() AS ErrorSeverity,
+    ERROR_PROCEDURE() AS ErrorProcedure,
+    ERROR_LINE() AS ErrorLine,
+    ERROR_MESSAGE() AS ErrorMessage;
+
+-- Transaction uncommittable
+    IF (XACT_STATE()) = -1
+      ROLLBACK TRANSACTION
+ 
+-- Transaction committable
+    IF (XACT_STATE()) = 1
+      COMMIT TRANSACTION
+END CATCH;
+GO

--- a/sddSchemaMods/1- [sdd].[A2BApplication].sql
+++ b/sddSchemaMods/1- [sdd].[A2BApplication].sql
@@ -23,13 +23,26 @@ BEGIN TRANSACTION CreateNewSddSchemaTableColumns
 		FROM INFORMATION_SCHEMA.COLUMNS
 		WHERE TABLE_SCHEMA = 'sdd'
 		AND TABLE_NAME = 'A2BApplicationApplyingSchool'
-		AND COLUMN_NAME = 'DynamicsKeyPersonId'
+		AND COLUMN_NAME = 'DynamicsApplyingSchoolId'
 	)
 	BEGIN
 		ALTER TABLE [sdd].[A2BApplicationApplyingSchool]
 		ADD	DynamicsApplyingSchoolId uniqueidentifier NULL,
 			Urn int NULL,
 			LocalAuthorityName nvarchar(max) NULL
+	END
+
+	IF NOT EXISTS
+	(
+		SELECT *
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = 'sdd'
+		AND TABLE_NAME = 'A2BApplicationApplyingSchool'
+		AND COLUMN_NAME = 'DynamicsApplicationId'
+	)
+	BEGIN
+		ALTER TABLE [sdd].[A2BApplicationApplyingSchool]
+		ADD	DynamicsApplicationId uniqueidentifier NULL
 	END
 
 	/*** [sdd].[A2BApplicationKeyPersons] ***/

--- a/sddSchemaMods/1- [sdd].[A2BApplication].sql
+++ b/sddSchemaMods/1- [sdd].[A2BApplication].sql
@@ -74,7 +74,7 @@ BEGIN TRANSACTION CreateNewSddSchemaTableColumns
 		ADD	DynamicsSchoolLoanId uniqueidentifier NULL
 	END
 
-	--COMMIT TRAN CreateNewSddSchemaTableColumns
+	COMMIT TRAN CreateNewSddSchemaTableColumns
 	--ROLLBACK TRAN CreateNewSddSchemaTableColumns
 
 END TRY


### PR DESCRIPTION
See ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/110289?McasTsid=26110

see task:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/114700?McasTsid=26110

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
1) Adding dynamics Id (guid) onto sdd.A2b tables
2) Un-commenting Urn & LocalAuthorityName on applying school for v1.5 A2B data conversion

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1. After running amended azure function, new columns in A2B sdd schema tables are populated
2. Dev tested by writing SQL scripts to clone data in following tables with application Id that doesn't exist in sdd.A2BApplication e.g. 'A2B_9999'
[Table("stg_application", Schema = "a2b")]
[Table("stg_applyingschool", Schema = "a2b")]
[Table("stg_keyperson", Schema = "a2b")]
[Table("stg_schoollease", Schema = "a2b")]
[Table("stg_schoolloan", Schema = "a2b")]

So that azure func picks up this test data and inserts into following tables:-
[Table("A2BApplication", Schema="sdd")] 
[Table("A2BApplicationApplyingSchool", Schema = "sdd")]
[Table("A2BApplicationKeyPersons", Schema = "sdd")]
[Table("A2BSchoolLease", Schema = "sdd")]
[Table("A2BSchoolLoan", Schema = "sdd")]

## Prerequisites
install the new columns onto the sdd schema tables by running:-
func-applytobecome-processapplicationform\sddSchemaMods\1- [sdd].[A2BApplication].sql - already ran against dev azure DB